### PR TITLE
download/index.html: update synology package

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -238,8 +238,7 @@
 		<img src="/images/platforms/synology.png">
 		
 			<b>Synology</b>
-			<br /><a href="http://forum.synology.com/enu/viewtopic.php?f=38&amp;t=14773">Newest Build</a>
-			<br /><a href="http://forum.synology.com/enu/viewforum.php?f=38">Forum Help</a>
+			<br /><a href="https://synocommunity.com/package/transmission">Newest Build</a>
 	</div>
 	<div>
 		<img src="/images/platforms/ip-box-9000.png">

--- a/download/index.html
+++ b/download/index.html
@@ -239,6 +239,7 @@
 		
 			<b>Synology</b>
 			<br /><a href="https://synocommunity.com/package/transmission">Newest Build</a>
+			<br /><a href="https://forum.synology.com/enu/viewforum.php?f=38">Support Forum</a>
 	</div>
 	<div>
 		<img src="/images/platforms/ip-box-9000.png">


### PR DESCRIPTION
The old forum thread is long dead: the latest build there is 2.13 from 2010. This commit points to [the package by SynoCommunity](https://synocommunity.com/package/transmission) instead ([GitHub](https://github.com/SynoCommunity)), which is pretty well maintained and quite popular — just look at [their GitHub repository](https://github.com/SynoCommunity/spksrc).