### PR TITLE
Fix Arch Linux download link

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -173,7 +173,7 @@
 		<img src="/images/platforms/arch-linux.png">
 		
 			<b>Arch Linux</b>
-			<br /><a href="https://www.archlinux.org/packages/?arch=&amp;repo=&amp;q=transmission&amp;last_update=&amp;limit=50">Official Packages</a>
+			<br /><a href="https://www.archlinux.org/packages/?q=transmission">Official Packages</a>
 	</div>
 	<div>
 		<img src="/images/platforms/slackware.png">


### PR DESCRIPTION
Empty but specified "arch" and "repo" fields now result in an error. "last_update" and "limit" don't have any effect either (anymore).