### PR TITLE
Update remote-gui address to actively maintained fork.

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -40,7 +40,7 @@
       <a href="http://github.com/fagga/transmission-remote-cli/tree/master">remote-cli</a>,
      (<a href="http://www.youtube.com/watch?v=hLz7ditUwY8">video review</a>),
       <a href="http://code.google.com/p/transmission-remote-gtk/">remote-gtk</a>,
-      <a href="http://code.google.com/p/transmisson-remote-gui/">remote-gui</a></li>
+      <a href="https://github.com/leonsoft-kras/transmisson-remote-gui">remote-gui</a></li>
 <li>Desktop remote controls:
       <a href="https://extensions.gnome.org/extension/365/transmission-daemon-indicator/">Transmission Indicator (GNOME Shell)</a></li>
 <li>Android remote controls:


### PR DESCRIPTION
Commit message:
Resources page currently points to inactive Google Code project https://code.google.com/p/transmisson-remote-gui/
After Google Code shutdown, yury_sidorov moved the project to SourceForge https://sourceforge.net/projects/transgui/
The SourceForge project is currently buggy and unmaintained. No release in over 2 years, no commits in over 1 year.
There is currently an active and maintained fork by leonsoft-kras on GitHub https://github.com/leonsoft-kras/transmisson-remote-gui
This commit replaces the original with the fork.

Alternatively the original project could be moved inactive/abandoned, but it seems like promoting the active and maintained fork is worthwhile.