### PR TITLE
Fix link to MacOS screenshot in the About page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -58,7 +58,7 @@ ship with Transmission.  When Belkin and Vuze Inc. partnered to write a <q><a hr
 
 <h3>Native.</h3>
 <p>Unlike many cross-platform applications, Transmission integrates seamlessly with your operating system.</p
-<p>The <a href="/images/screenshots/Mac-Large.jpg">Mac OS X interface</a> is written in Objective-C and uses <a href="http://growl.info/">Growl notifications</a> and dock badging to keep you informed.</p>
+<p>The <a href="/images/screenshots/Mac-Large.png">Mac OS X interface</a> is written in Objective-C and uses <a href="http://growl.info/">Growl notifications</a> and dock badging to keep you informed.</p>
 
 <blockquote>
 <span style="font-style: italic"><q>It's fast, it's extremely lightweight, and &mdash; even though it's available for a variety of platforms &mdash; it behaves just as you'd expect a Mac program to.</q></span>


### PR DESCRIPTION
The About page currently links to https://transmissionbt.com/images/screenshots/Mac-Large.jpg, but the correct file extension is `.png`.