### PR TITLE
Add code signing policy section to downloads page

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -122,6 +122,9 @@
         <span id="msi32-checksum"></span><br/>
         <span id="msi64-checksum"></span><br/>
 
+        <h2>Code Signing Policy</h2>
+        <span>Windows MSI packages: free code signing provided by <a href="https://signpath.io/">SignPath.io</a>, certificate by <a href="https://signpath.org/">SignPath Foundation</a>.</span><br/>
+
 	<h2>Unix Distros</h2><br />
 	<div>
 		<img src="/images/platforms/ubuntu.png">


### PR DESCRIPTION
This is per SignPath's requirements according to their "Code of Conduct for Open Source projects". It's a minimal change but once their CoC is finalized we'll potentially need to make some more adjustments.