### PR TITLE
Add Transmission PowerShell Module in powershellgallery link to add-ons

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -68,7 +68,8 @@
 <li>Remote control libraries: <a href="https://github.com/brycied00d/PHP-Transmission-Class/">PHP-Transmission-Class</a>,
                               <a href="http://rubygems.org/gems/transmission_api">transmission_api (Ruby)</a>,
                               <a href="https://bitbucket.org/blueluna/transmissionrpc">transmissionrpc (Python)</a>,
-                              <a href="http://search.cpan.org/~jhthorsen/Transmission-Client-0.0603/">Transmission::Client (Perl)</a></li>
+                              <a href="http://search.cpan.org/~jhthorsen/Transmission-Client-0.0603/">Transmission::Client (Perl)</a>,
+                              <a href="https://www.powershellgallery.com/packages/Transmission">Transmission PowerShell Module</a></li>
 
 <li>3rd Party Forums: <a href="http://www.readynas.com/forum/viewtopic.php?f=36&t=41756">NETGEAR ReadyNAS</a>,
                       <a href="http://forum.qnap.com/viewforum.php?f=221">QNAP</a>,

--- a/resources/index.html
+++ b/resources/index.html
@@ -59,6 +59,9 @@
 <li>XBMC plugin:
       <a href="http://wiki.xbmc.org/index.php?title=Add-on:Transmission">Transmission-XBMC</a>
      (<a href="https://github.com/correl/Transmission-XBMC/commits/master">github repo</a>)</li>
+<li>PowerShell module:
+           <a href="https://www.powershellgallery.com/packages/Transmission">Transmission</a>
+          (<a href="https://github.com/trossr32/ps-transmission">github repo</a>)</li>
 </ul>
 
 
@@ -68,8 +71,7 @@
 <li>Remote control libraries: <a href="https://github.com/brycied00d/PHP-Transmission-Class/">PHP-Transmission-Class</a>,
                               <a href="http://rubygems.org/gems/transmission_api">transmission_api (Ruby)</a>,
                               <a href="https://bitbucket.org/blueluna/transmissionrpc">transmissionrpc (Python)</a>,
-                              <a href="http://search.cpan.org/~jhthorsen/Transmission-Client-0.0603/">Transmission::Client (Perl)</a>,
-                              <a href="https://www.powershellgallery.com/packages/Transmission">Transmission PowerShell Module</a></li>
+                              <a href="http://search.cpan.org/~jhthorsen/Transmission-Client-0.0603/">Transmission::Client (Perl)</a></li>
 
 <li>3rd Party Forums: <a href="http://www.readynas.com/forum/viewtopic.php?f=36&t=41756">NETGEAR ReadyNAS</a>,
                       <a href="http://forum.qnap.com/viewforum.php?f=221">QNAP</a>,


### PR DESCRIPTION
I have created a PowerShell module with multiple cmdlets that interface with the Transmission RPC API and was hoping a link the the module in the PowerShell Gallery could be added to the add-ons page.

For reference here's the PowerShell gallery link and a link to the project on GitHub:

https://www.powershellgallery.com/packages/Transmission
https://github.com/trossr32/ps-transmission