### PR TITLE
Fix broken link for windows x64 and linux & unix

### DIFF
--- a/download.html
+++ b/download.html
@@ -108,7 +108,7 @@
                      <p> <a
                            href="https://github.com/transmission/transmission-releases/raw/master/transmission-3.00-x86.msi">transmission-3.00-x86.msi</a>
                         <br> <a
-                           href="https://github.com/transmission/transmission-releases/raw/master/Transmission-3.00-x64.msi">transmission-3.00-x64.msi</a>
+                           href="https://github.com/transmission/transmission-releases/raw/master/transmission-3.00-x64.msi">transmission-3.00-x64.msi</a>
                      <!-- stubbing them out so they can be reactivated when the beta is ready -->
                      <!--
                         <br> <a

--- a/download.html
+++ b/download.html
@@ -131,7 +131,7 @@
                      <h3>Linux &amp; Unix</h3>
                      <p> <a href="#unixdistros">Linux &amp; Unix Distros</a>
                         <br> <a
-                           href="https://github.com/transmission/transmission-releases/raw/master/Transmission-3.00.tar.xz">transmission-3.00.tar.xz</a>
+                           href="https://github.com/transmission/transmission-releases/raw/master/transmission-3.00.tar.xz">transmission-3.00.tar.xz</a>
                         <br>
                      <!-- stubbing them out so they can be reactivated when the beta is ready -->
                      <!--


### PR DESCRIPTION
Download link for windows x64 installer was broken on website

https://github.com/transmission/transmission-releases/raw/master/Transmission-3.00-x64.msi
fixed to
https://github.com/transmission/transmission-releases/raw/master/transmission-3.00-x64.msi
-----------------------------------------------------------------
Download link for Linux & Unix installer was broken on website

https://github.com/transmission/transmission-releases/raw/master/Transmission-3.00.tar.xz
fixed to
https://github.com/transmission/transmission-releases/raw/master/transmission-3.00.tar.xz