### PR TITLE
Fixed broken windows download links

### DIFF
--- a/download.html
+++ b/download.html
@@ -106,9 +106,11 @@
                         alt="Windows" aria-hidden="true">
                      <h3>Windows</h3>
                      <p> <a
-                           href="https://github.com/transmission/transmission-releases/raw/master/transmission-3.00-x86.msi">transmission-3.00-x86.msi</a>
+                           href="https://github.com/transmission/transmission/releases/download/3.00/transmission-3.00-x86.msi">transmission-3.00-x86.msi</a>
+                        <!-- Fixed broken link - Airei -->
                         <br> <a
-                           href="https://github.com/transmission/transmission-releases/raw/master/Transmission-3.00-x64.msi">transmission-3.00-x64.msi</a>
+                           href="https://github.com/transmission/transmission/releases/download/3.00/transmission-3.00-x64.msi">transmission-3.00-x64.msi</a>
+                        <!-- Fixed broken link - Airei -->
                      <!-- stubbing them out so they can be reactivated when the beta is ready -->
                      <!--
                         <br> <a


### PR DESCRIPTION
https://github.com/transmission/transmission-releases/raw/master/transmission-3.00-x86.msi changed to https://github.com/transmission/transmission/releases/download/3.00/transmission-3.00-x86.msi | https://github.com/transmission/transmission-releases/raw/master/Transmission-3.00-x64.msi changed to https://github.com/transmission/transmission/releases/download/3.00/transmission-3.00-x64.msi