### PR TITLE
Link to Clutch for Android

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -103,6 +103,7 @@
                         href="https://github.com/AndreyPavlenko/transmissionbtc">transmissionbtc</a>,&nbsp; <a
                         href="https://github.com/6c65726f79/Transmissionic">Transmissionic</a>,&nbsp; <a
                         href="https://github.com/y-polek/TransmissionRemote">TransmissionRemote</a>,&nbsp; <a
+                        href="https://play.google.com/store/apps/details?id=eu.tmdpw.clutch.lite">Clutch Lite</a>,&nbsp; <a
                         href="https://play.google.com/store/search?q=transmission+torrent&c=apps">Search Google Play</a>
                   <li class="list-group-item">iOS remote controls: <a
                         href="https://github.com/alcheck/transshift">transshift</a>,&nbsp; <a

--- a/addons.html
+++ b/addons.html
@@ -103,7 +103,7 @@
                         href="https://github.com/AndreyPavlenko/transmissionbtc">transmissionbtc</a>,&nbsp; <a
                         href="https://github.com/6c65726f79/Transmissionic">Transmissionic</a>,&nbsp; <a
                         href="https://github.com/y-polek/TransmissionRemote">TransmissionRemote</a>,&nbsp; <a
-                        href="https://play.google.com/store/apps/details?id=eu.tmdpw.clutch.lite">Clutch Lite</a>,&nbsp; <a
+                        href="https://play.google.com/store/apps/details?id=eu.tmdpw.clutch">Clutch</a>,&nbsp; <a
                         href="https://play.google.com/store/search?q=transmission+torrent&c=apps">Search Google Play</a>
                   <li class="list-group-item">iOS remote controls: <a
                         href="https://github.com/alcheck/transshift">transshift</a>,&nbsp; <a


### PR DESCRIPTION
I recently built [Clutch](https://play.google.com/store/apps/details?id=eu.tmdpw.clutch) for Android, in an attempt to provide a Transmission remote with a more modern look-and-feel. This PR adds it to the website.