### PR TITLE
Fix cutoff gears background image

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
             </div>
          </div>
       </section>
-      <div class="bg-dark bg-rainbow text-secondary px-sm-4 px-md-5">
+      <section class="bg-dark bg-rainbow text-secondary px-sm-4 px-md-5">
          <section class="container px-4">
             <div class="row flex-lg-row-reverse g-5 py-sm-2 py-md-5">
                <div class="col-lg-6 text-center d-flex align-items-center justify-content-center"> <img
@@ -192,7 +192,7 @@
             </div>
          </section>
          <section class="bg-dark bg-rainbow text-secondary px-sm-4 px-md-5">
-            <div class="px-4 pt-0 mb-5 text-center text-white">
+            <div class="px-4 pt-0 text-center text-white">
                <div class="col-lg-10 mx-auto mb-4">
                   <h1 class="display-5 fw-bold lh-1 mb-3 mt-3 text-center">Sleek &amp; Feature Rich</h1>
                   <p class="lead mb-2 mt-2 text-center lh-lg" style="color: white!important;">The features you want from
@@ -215,8 +215,8 @@
                </div>
             </div>
          </section>
-      </div>
-      <section class="px-4 pb-5 pt-0 news-section">
+      </section>
+      <section class="px-4 py-5 news-section">
          <h2 class="display-6 fw-bold mb-4 text-center">News &amp; Updates</h2>
          <div class="col-lg-8 mx-auto fs-5 news-content">
 


### PR DESCRIPTION
This fixes the cutoff gears background image in the news section (at the bottom of the [homepage](https://transmissionbt.com/) in light mode) by removing the bottom margin of the previous section and adding it to the news section. 