### PR TITLE
chore: fix html-validator warnings

### DIFF
--- a/download.html
+++ b/download.html
@@ -61,7 +61,7 @@
                <li> <a href="/donate" class="nav-link px-2">Donate</a> </li>
             </ul>
             <a class="btn btn-outline-light navgitbttn" href="https://github.com/transmission/transmission"
-               role="button"> <i class="fa-brands fa-github"></i>&nbsp;GitHub </a>
+               role="button"> <i class="fa-brands fa-github">&nbsp;</i>&nbsp;GitHub </a>
          </nav>
          <!-- NAVIGATION END -->
       </div>
@@ -82,7 +82,7 @@
                         <a
                            href="https://github.com/transmission/transmission-releases/raw/master/Transmission-4.0.0-beta.1.dmg">transmission-4.0.0-beta.1.dmg</a>
                         <br>Requires Mac OS X 10.10 or later
-                        <br> <i class="fa-brands fa-apple"></i>&nbsp;&nbsp; 4.0 Apple Silicon Native
+                        <br> <i class="fa-brands fa-apple">&nbsp;</i>&nbsp;&nbsp; 4.0 Apple Silicon Native
                         <br> <small class="text-muted">
                            <a href="https://build.transmissionbt.com/job/trunk-mac/">Nightly
                               builds</a>&nbsp;&nbsp;&nbsp;&#47;&nbsp;&nbsp; <a
@@ -242,7 +242,7 @@
                <div class="col-md-3 themed-grid-col pb-3"> <img src="/assets/images/distro_logos/opensuse_logo.svg"
                      class="mb-3 distro-logo" alt="OpenSUSE" aria-hidden="true">
                   <h3>OpenSUSE</h3>
-                  <p> <a href="http://software.opensuse.org/search?baseproject=openSUSE:11.3&q=transmission">Official
+                  <p> <a href="https://software.opensuse.org/search?baseproject=ALL&amp;q=transmission">Official
                         Packages</a> </p>
                </div>
                <!-- CentOS -->
@@ -403,7 +403,7 @@
             </ul>
             <!-- NAVIGATION END -->
             <a class="btn btn-outline-light mb-0 mt-3 px-4" href="https://github.com/transmission/transmission"
-               role="button"> <i class="fa-brands fa-github"></i>&nbsp;GitHub </a>
+               role="button"> <i class="fa-brands fa-github">&nbsp;</i>&nbsp;GitHub </a>
          </div>
       </div>
    </footer>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
                <li> <a href="/donate" class="nav-link px-2">Donate</a> </li>
             </ul>
             <a class="btn btn-outline-light navgitbttn" href="https://github.com/transmission/transmission"
-               role="button"> <i class="fa-brands fa-github"></i>&nbsp;GitHub </a>
+               role="button"> <i class="fa-brands fa-github">&nbsp;</i>&nbsp;GitHub </a>
          </nav>
          <!-- NAVIGATION END -->
       </div>
@@ -78,14 +78,13 @@
                      <br>
                      <!-- BUTTONS START -->
                      <a class="btn btn-danger btn-lg px-4 fw-bold mt-3 mx-auto" href="/download" role="button"> <i
-                           class="fa-solid fa-download"></i>&nbsp;&nbsp;Download v3.0 stable</a>
+                           class="fa-solid fa-download">&nbsp;</i>&nbsp;&nbsp;Download v3.0 stable</a>
                      <br>
                      <a class="btn btn-warning btn-md px-4 fw-bold mt-2 mx-auto" href="/download" role="button"> <i
-                           class="fa-solid fa-download"></i>&nbsp;&nbsp;Download v4.0 beta</a>
+                           class="fa-solid fa-download">&nbsp;</i>&nbsp;&nbsp;Download v4.0 beta</a>
                      <br>
                      <!-- Button Modal Trigger --><b class="modal-link">
-                        <a class="mt-2 text-muted" data-bs-toggle="modal" data-bs-target="#ChangeLogModal"> Change
-                           Log</a>
+                        <a class="mt-2 text-muted" href="https://github.com/transmission/transmission/releases/">Release Notes</a>
                      </b>
                      <!-- BUTTONS END -->
                   </p>
@@ -142,15 +141,15 @@
                   <h5 class="mb-3 text-center">Unlike many cross-platform applications, Transmission integrates
                      seamlessly with your operating system.</h5>
                   <p class="lead mb-1 lh-lg text-center"> <i
-                        class="fa-brands fa-apple"></i>&nbsp;&nbsp;&nbsp;Transmission on macOS is a truly native and
+                        class="fa-brands fa-apple">&nbsp;</i>&nbsp;&nbsp;&nbsp;Transmission on macOS is a truly native and
                      polished experience. This isn't some cross-platform app that treats macOS as an afterthought. With
                      a sleek and simple interface, Transmission meets or exceeds Apple UI standards while using native
                      features.
                      <br>v4.0 is Apple Silicon Native!
                   </p>
-                  <p class="lead mb-1 lh-lg text-center"> <i class="fa-brands fa-windows"></i>&nbsp;&nbsp;&nbsp;The
+                  <p class="lead mb-1 lh-lg text-center"> <i class="fa-brands fa-windows">&nbsp;</i>&nbsp;&nbsp;&nbsp;The
                      Qt-based Windows UI has been modernized and is fully Windows 11 ready. </p>
-                  <p class="lead mb-3 lh-lg text-center"> <i class="fa-brands fa-linux"></i>&nbsp;&nbsp;&nbsp;The GTK
+                  <p class="lead mb-3 lh-lg text-center"> <i class="fa-brands fa-linux">&nbsp;</i>&nbsp;&nbsp;&nbsp;The GTK
                      interface has been carefully written to follow the GNOME Human Interface Guidelines and features.
                   </p>
                </div>
@@ -194,10 +193,10 @@
                      communications, tracker editing, speed limits, and more.</p>
                   <!-- BUTTONS START -->
                   <a class="btn btn-danger btn-lg x-4 me-sm-3 fw-bold mx-2 btn-min-width-300 mt-2" href="/download"
-                     role="button"> <i class="fa-solid fa-download"></i>&nbsp;&nbsp;Download v3.0 stable
+                     role="button"> <i class="fa-solid fa-download">&nbsp;</i>&nbsp;&nbsp;Download v3.0 stable
                   </a>
                   <a class="btn btn-warning btn-lg x-4 me-sm-3 fw-bold mx-2 btn-min-width-300 mt-2" href="/download"
-                     role="button"> <i class="fa-solid fa-download"></i>&nbsp;&nbsp;Download v4.0 beta </span>
+                     role="button"> <i class="fa-solid fa-download">&nbsp;</i>&nbsp;&nbsp;Download v4.0 beta
                   </a>
                </div>
                <div class="overflow-hidden" style="max-height: 30vh;">
@@ -227,16 +226,16 @@
                <div class="d-grid d-md-flex justify-content-sm-center">
                   <a class="btn btn-outline-dark btn-lg px-4 me-sm-3 fw-bold btn-min-width-320"
                      href="https://github.com/transmission/transmission" role="button"> <i
-                        class="fa-brands fa-github"></i>&nbsp;Development on GitHub </a>
+                        class="fa-brands fa-github">&nbsp;</i>&nbsp;Development on GitHub </a>
                </div>
                <div class="d-grid d-md-flex justify-content-sm-center">
                   <a class="btn btn-danger btn-lg x-4 me-sm-3 fw-bold btn-min-width-320" href="/download"
-                     role="button"> <i class="fa-solid fa-download"></i>&nbsp;&nbsp;Download v3.00 stable
+                     role="button"> <i class="fa-solid fa-download">&nbsp;</i>&nbsp;&nbsp;Download v3.00 stable
                   </a>
                </div>
                <div class="d-grid d-md-flex justify-content-sm-center">
                   <a class="btn btn-warning btn-lg x-4 me-sm-3 fw-bold btn-min-width-320" href="/download"
-                     role="button"> <i class="fa-solid fa-download"></i>&nbsp;&nbsp;Download v4.00 beta </span>
+                     role="button"> <i class="fa-solid fa-download">&nbsp;</i>&nbsp;&nbsp;Download v4.00 beta
                   </a>
                </div>
             </div>
@@ -268,151 +267,11 @@
             </ul>
             <!-- NAVIGATION END -->
             <a class="btn btn-outline-light mb-0 mt-3 px-4" href="https://github.com/transmission/transmission"
-               role="button"> <i class="fa-brands fa-github"></i>&nbsp;GitHub </a>
+               role="button"> <i class="fa-brands fa-github">&nbsp;</i>&nbsp;GitHub </a>
          </div>
       </div>
    </footer>
    <script src="/assets/bootstrap.bundle.min.js"></script>
-   <!-- CHANGE LOG MODAL START -->
-   <div class="modal fade" id="ChangeLogModal" tabindex="-1" aria-labelledby="changeLogModalLable" aria-hidden="true">
-      <div class="modal-dialog modal-xl">
-         <div class="modal-content">
-            <div class="modal-header">
-               <h2 class="modal-title" id="changeLogModalLable">Transmission v3.00 Latest: May 22, 2020</h2>
-               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body changeLogModalLablecontent changelog">
-               <!-- CHANGE LOG MODAL CONTENT START: Edit Content Below-->
-               <a class="btn btn-outline-dark btn-md px-4 mb-3 me-sm-3 fw-bold"
-                  href="https://github.com/transmission/transmission" role="button"> <i
-                     class="fa-brands fa-github"></i>&nbsp;Development on GitHub </a>
-               <h3>All Platforms</h3>
-               <ul>
-                  <li>Allow the RPC server to listen on an IPv6 address (#161)</li>
-                  <li>Change TR_CURL_SSL_VERIFY to TR_CURL_SSL_NO_VERIFY and enable verification by default (#334)</li>
-                  <li>Go back to using hash as base name for resume and torrent files (those stored in configuration
-                     directory) (#122)</li>
-                  <li>Handle "fields" argument in "session-get" RPC request; if "fields" array is present in arguments,
-                     only return session fields specified; otherwise return all the fields as before</li>
-                  <li>Limit the number of incorrect authentication attempts in embedded web server to 100 to prevent
-                     brute-force attacks (#371)</li>
-                  <li>Set idle seed limit range to 1..40320 (4 weeks tops) in all clients (#212)</li>
-                  <li>Add Peer ID for Xfplay, PicoTorrent, Free Download Manager, Folx, Baidu Netdisk torrent clients
-                     (#256, #285, #355, #363, #386)</li>
-                  <li>Announce INT64_MAX as size left if the value is unknown (helps with e.g. Amazon S3 trackers)
-                     (#250)</li>
-                  <li>Add TCP_FASTOPEN support (should result in slight speedup) (#184)</li>
-                  <li>Improve ToS handling on IPv6 connections (#128, #341, #360, #692, #737)</li>
-                  <li>Abort handshake if establishing DH shared secret fails (leads to crash) (#27)</li>
-                  <li>Don't switch trackers while announcing (leads to crash) (#297)</li>
-                  <li>Improve completion scripts execution and error handling; add support for .cmd and .bat files on
-                     Windows (#405)</li>
-                  <li>Maintain a "session ID" file (in temporary directory) to better detect whether session is local or
-                     remote; return the ID as part of "session-get" response (TRAC-5348, #861)</li>
-                  <li>Change torrent location even if no data move is needed (#35)</li>
-                  <li>Support CIDR-notated blocklists (#230, #741)</li>
-                  <li>Update the resume file before running scripts (#825)</li>
-                  <li>Make multiscrape limits adaptive (#837)</li>
-                  <li>Add labels support to libtransmission and transmission-remote (#822)</li>
-                  <li>Parse session-id header case-insensitively (#765)</li>
-                  <li>Sanitize suspicious path components instead of rejecting them (#62, #294)</li>
-                  <li>Load CA certs from system store on Windows / OpenSSL (#446)</li>
-                  <li>Add support for mbedtls (formely polarssl) and wolfssl (formely cyassl), LibreSSL (#115, #116,
-                     #284, #486, #524, #570)</li>
-                  <li>Fix building against OpenSSL 1.1.0+ (#24)</li>
-                  <li>Fix quota support for uClibc-ng 1.0.18+ and DragonFly BSD (#42, #58, #312)</li>
-                  <li>Fix a number of memory leaks (magnet loading, session shutdown, bencoded data parsing) (#56)</li>
-                  <li>Bump miniupnpc version to 2.0.20170509 (#347)</li>
-                  <li>CMake-related improvements (Ninja generator, libappindicator, systemd, Solaris and macOS) (#72,
-                     #96, #117, #118, #133, #191)</li>
-                  <li>Switch to submodules to manage (most of) third-party dependencies</li>
-                  <li>Fail installation on Windows if UCRT is not installed</li>
-               </ul>
-               <h3>Mac Client</h3>
-               <ul>
-                  <li>Bump minimum macOS version to 10.10</li>
-                  <li>Dark Mode support (#644, #722, #757, #779, #788)</li>
-                  <li>Remove Growl support, notification center is always used (#387)</li>
-                  <li>Fix autoupdate on High Sierra and up by bumping the Sparkle version (#121, #600)</li>
-                  <li>Transition to ARC (#336)</li>
-                  <li>Use proper UTF-8 encoding (with macOS-specific normalization) when setting download/incomplete
-                     directory and completion script paths (#11)</li>
-                  <li>Fix uncaught exception when dragging multiple items between groups (#51)</li>
-                  <li>Add flat variants of status icons for message log (#134)</li>
-                  <li>Optimize image resources size (#304, #429)</li>
-                  <li>Update file icon when file name changes (#37)</li>
-                  <li>Update translations</li>
-               </ul>
-               <h3>GTK Client</h3>
-               <ul>
-                  <li>Add queue up/down hotkeys (#158)</li>
-                  <li>Modernize the .desktop file (#162)</li>
-                  <li>Add AppData file (#224)</li>
-                  <li>Add symbolic icon variant for the Gnome top bar and when the high contrast theme is in use (#414,
-                     #449)</li>
-                  <li>Update file icon when its name changes (#37)</li>
-                  <li>Switch from intltool to gettext for translations (#584, #647)</li>
-                  <li>Update translations, add new translations for Portuguese (Portugal)</li>
-               </ul>
-               <h3>Qt Client</h3>
-               <ul>
-                  <li>Bump minimum Qt version to 5.2</li>
-                  <li>Fix dropping .torrent files into main window on Windows (#269)</li>
-                  <li>Fix prepending of drive letter to various user-selected paths on Windows (#236, #307, #404, #437,
-                     #699, #723, #877)</li>
-                  <li>Fix sorting by progress in presence of magnet transfers (#234)</li>
-                  <li>Fix .torrent file trashing upon addition (#262)</li>
-                  <li>Add queue up/down hotkeys (#158)</li>
-                  <li>Reduce torrent properties (file tree) memory usage</li>
-                  <li>Display tooltips in torrent properties (file tree) in case the names don't fit (#411)</li>
-                  <li>Improve UI look on hi-dpi displays (YMMV)</li>
-                  <li>Use session ID (if available) to check if session is local or not (#861)</li>
-                  <li>Use default (instead of system) locale to be more flexible (#130)</li>
-                  <li>Modernize the .desktop file (#162)</li>
-                  <li>Update translations, add new translations for Afrikaans, Catalan, Danish, Greek, Norwegian Bokmål,
-                     Slovenian</li>
-               </ul>
-               <h3>Daemon</h3>
-               <ul>
-                  <li>Use libsystemd instead of libsystemd-daemon (TRAC-5921)</li>
-                  <li>Harden transmission-daemon.service by disallowing privileges elevation (#795)</li>
-                  <li>Fix exit code to be zero when dumping settings (#487)</li>
-               </ul>
-               <h3>Web Client</h3>
-               <ul>
-                  <li>Fix tracker error XSS in inspector (CVE-?)</li>
-                  <li>Fix performance issues due to improper use of setInterval() for UI refresh (TRAC-6031)</li>
-                  <li>Fix recognition of https:// links in comments field (#41, #180)</li>
-                  <li>Fix torrent list style in Google Chrome 59+ (#384)</li>
-                  <li>Show ETA in compact view on non-mobile devices (#146)</li>
-                  <li>Show upload file button on mobile devices (#320, #431, #956)</li>
-                  <li>Add keyboard hotkeys for web interface (#351)</li>
-                  <li>Disable autocompletion in torrent URL field (#367)</li>
-               </ul>
-               <h3>Utils</h3>
-               <ul>
-                  <li>Prevent crash in transmission-show displaying torrents with invalid creation date (#609)</li>
-                  <li>Handle IPv6 RPC addresses in transmission-remote (#247)</li>
-                  <li>Add --unsorted option to transmission-show (#767)</li>
-                  <li>Widen the torrent-id column in transmission-remote for cleaner formatting (#840)</li>
-               </ul>
-               <h3>Code Signing Policy</h3>
-               <ul>
-                  <li>Windows MSI packages: free code signing provided by SignPath.io, certificate by SignPath
-                     Foundation</li>
-               </ul>
-               <a class="btn btn-outline-dark btn-lg px-4 me-sm-3 fw-bold"
-                  href="https://github.com/transmission/transmission" role="button"> <i
-                     class="fa-brands fa-github"></i>&nbsp;Development on GitHub </a>
-               <!-- CHANGE LOG MODAL CONTENT END -->
-            </div>
-            <div class="modal-footer">
-               <button type="button" class="btn btn-lg btn-danger mx-auto px-5" data-bs-dismiss="modal">Close</button>
-            </div>
-         </div>
-      </div>
-   </div>
-   <!-- CHANGE LOG MODAL END -->
 </body>
 
 </html>


### PR DESCRIPTION
These are mostly minor things, e.g. empty `<i></i>` blocks, but also I introduced a couple of broken elements in the previous 4.0.0-beta.1 commit.