### PR TITLE
Update download instructions for Fedora to use dnf

### DIFF
--- a/download.html
+++ b/download.html
@@ -213,7 +213,7 @@
                <div class="col-md-3 themed-grid-col pb-3"> <img src="/assets/images/distro_logos/Fedora-logo.svg"
                      class="mb-3 distro-logo" alt="Fedora Linux" aria-hidden="true">
                   <h3>Fedora</h3>
-                  <p> <code>$ yum install transmission</code> </p>
+                  <p> <code>$ dnf install transmission</code> </p>
                </div>
                <!-- Arch -->
                <div class="col-md-3 themed-grid-col pb-3"> <img src="/assets/images/distro_logos/arch_linux_logo.svg"


### PR DESCRIPTION
Fedora switched from yum to dnf some time ago, reflect that on download page.