### PR TITLE
Fix Download text overflowing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -38,6 +38,10 @@ main a:hover {
   min-width: 120px;
 }
 
+,card-text {
+  overflow: scroll;
+}
+
 @media (min-width: 992px) {
   .homepageheader {
     background-image: url(images/homepage/gear_backgrounds/gear_1_background_2.jpg), url(images/homepage/gear_backgrounds/gear_2_background_2.jpg);


### PR DESCRIPTION
After some testing, setting the overflow attribute to scroll regardless of screen size doesn't break anything, even though it appears because of the `(min-width: 576px)` media query set in bootsrap, which I am not very familiar with. Seemed like a quick and easy fix to me.

![Screenshot 2023-02-09 09 17 27](https://user-images.githubusercontent.com/34194191/217746094-fd1d0899-bd40-4c15-a54b-7335d43600e7.png)
![Screenshot 2023-02-09 09 17 24](https://user-images.githubusercontent.com/34194191/217746102-1e33518a-364c-45a7-80c3-9f10af0626e7.png)
