### PR TITLE
Introduce the thin-client mode for the Qt client

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,8 +149,9 @@
                      features.
                      <br>v4.0 is Apple Silicon Native!
                   </p>
-                  <p class="lead mb-1 lh-lg text-center"> <i class="fa-brands fa-windows">&nbsp;</i>&nbsp;&nbsp;&nbsp;The
-                     Qt-based Windows UI has been modernized and is fully Windows 11 ready. </p>
+                  <p class="lead mb-1 lh-lg text-center"> <i class="fa-brands fa-windows">&nbsp;</i>&nbsp;&nbsp;&nbsp;The Qt-based
+                     Windows UI has been designed to run both as a standalone Windows application and as a thin-client connected to a
+                     Transmission daemon running on a remote server. Now, it has been modernized and is fully Windows 11 ready </p>
                   <p class="lead mb-3 lh-lg text-center"> <i class="fa-brands fa-linux">&nbsp;</i>&nbsp;&nbsp;&nbsp;The GTK
                      interface has been carefully written to follow the GNOME Human Interface Guidelines and features.
                   </p>


### PR DESCRIPTION
I think we really need to do a better advertisement of the thin-client mode for the Qt client. Very few people realize that the QT client actually can function as a thin client like Deluge.

On the front page of transmissionbt.com, instead of just saying "The Qt-based Windows UI has been modernized and is fully Windows 11 ready.", maybe we could also point out it can function as a thin client? Like "The QT-based Windows UI has been designed to run as both a standalone Windows application and a thin-client to connect to a Transmission daemon running on a remote server. Now, it has been modernized and is fully Windows 11 ready".

As a reference, this is on Deluge website: "Deluge has been designed to run as both a normal standalone desktop application and as a ​client-server. In Thinclient mode a Deluge daemon handles all the BitTorrent activity and is able to run on headless machines with the user-interfaces connecting remotely from any other platform."