### PR TITLE
Swap download page links to correct headings

### DIFF
--- a/download.html
+++ b/download.html
@@ -120,8 +120,7 @@
                         aria-hidden="true">
                      <h3>Linux &amp; Unix</h3>
                      <p>
-                        <a href="https://github.com/transmission/transmission/releases/download/4.0.6/transmission-4.0.6.tar.xz">transmission-4.0.6.tar.xz</a>
-                        <p/>
+                        <a href="#unixdistros">Distros</a>
                         <small class="text-muted">
                            <a href="https://github.com/transmission/transmission-releases">Previous Releases</a>
                            &nbsp;&nbsp;&nbsp;&#47;&nbsp;&nbsp;
@@ -139,8 +138,7 @@
                         alt="Box Logo" aria-hidden="true" style="height:60px;">
                      <h3>Source Code</h3>
                      <p>
-                           <a
-                           href="#unixdistros">Distros</a> &nbsp;&#124;&nbsp;&nbsp;<a
+                           <a href="https://github.com/transmission/transmission/releases/download/4.0.6/transmission-4.0.6.tar.xz">transmission-4.0.6.tar.xz</a>&nbsp;&#124;&nbsp;&nbsp;<a
                            href="https://build.transmissionbt.com/job/trunk-linux/">Nightlies</a>&nbsp;&nbsp;&#124;&nbsp;&nbsp;<a
                            href="https://github.com/transmission/transmission-releases">Previous releases</a>
                      </p>


### PR DESCRIPTION
Shouldn't the link to the source code be under "Source Code" and the link to Linux & Unix Distros be under "Linux & Unix"?