### PR TITLE
docs: add Tewi to addons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -95,7 +95,8 @@
                         href="https://github.com/tremc/tremc">tremc</a>,&nbsp; <a
                         href="https://github.com/rndusr/stig">stig</a>,&nbsp; <a
                         href="https://github.com/dylanaraps/torque">torque</a>,&nbsp; <a
-                        href="https://github.com/openscopeproject/TrguiNG">TrguiNG</a>
+                        href="https://github.com/openscopeproject/TrguiNG">TrguiNG</a>,&nbsp; <a                                                                 
+                        href="https://github.com/anlar/tewi">Tewi</a>
                   </li>
                   <li class="list-group-item">Desktop remote controls: <a
                         href="https://extensions.gnome.org/extension/365/transmission-daemon-indicator/">Transmission


### PR DESCRIPTION
Hi,
I have started development of new TUI client for Transmission - [Tewi](https://github.com/anlar/tewi). And I would like to add it to addon's page.