### PR TITLE
Add 'Documentation' link in menu

### DIFF
--- a/404.html
+++ b/404.html
@@ -49,6 +49,7 @@
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 mt-4 justify-content-center mb-md-0" role="menu">
                <li> <a href="/" class="nav-link px-2" role="menuitem">Home</a> </li>
                <li> <a href="/download" class="nav-link px-2" role="menuitem">Download</a> </li>
+               <li> <a href="https://github.com/transmission/transmission/blob/main/docs/README.md" class="nav-link px-2" role="menuitem">Documentation</a> </li>
                <li> <a href="/addons" class="nav-link px-2" role="menuitem">Add-Ons</a> </li>
                <li class="dropdown"> <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="menuitem"
                      aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">Community</a>

--- a/addons.html
+++ b/addons.html
@@ -49,6 +49,7 @@
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 mt-4 justify-content-center mb-md-0" role="menu">
                <li> <a href="/" class="nav-link px-2" role="menuitem">Home</a> </li>
                <li> <a href="/download" class="nav-link px-2" role="menuitem">Download</a> </li>
+               <li> <a href="https://github.com/transmission/transmission/blob/main/docs/README.md" class="nav-link px-2" role="menuitem">Documentation</a> </li>
                <li> <a href="/addons" class="nav-link px-2 active" role="menuitem">Add-Ons</a> </li>
                <li class="dropdown"> <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="menuitem"
                      aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">Community</a>

--- a/donate.html
+++ b/donate.html
@@ -49,6 +49,7 @@
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 mt-4 justify-content-center mb-md-0" role="menu">
                <li> <a href="/" class="nav-link px-2" role="menuitem">Home</a> </li>
                <li> <a href="/download" class="nav-link px-2" role="menuitem">Download</a> </li>
+               <li> <a href="https://github.com/transmission/transmission/blob/main/docs/README.md" class="nav-link px-2" role="menuitem">Documentation</a> </li>
                <li> <a href="/addons" class="nav-link px-2" role="menuitem">Add-Ons</a> </li>
                <li class="dropdown"> <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="menuitem"
                      aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">Community</a>

--- a/download.html
+++ b/download.html
@@ -49,6 +49,7 @@
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 mt-4 justify-content-center mb-md-0" role="menu">
                <li> <a href="/" class="nav-link px-2" role="menuitem">Home</a> </li>
                <li> <a href="/download" class="nav-link px-2 active" role="menuitem">Download</a> </li>
+               <li> <a href="https://github.com/transmission/transmission/blob/main/docs/README.md" class="nav-link px-2" role="menuitem">Documentation</a> </li>
                <li> <a href="/addons" class="nav-link px-2" role="menuitem">Add-Ons</a> </li>
                <li class="dropdown"> <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="menuitem"
                      aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">Community</a>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 mt-4 justify-content-center mb-md-0" role="menu">
                <li> <a href="/" class="nav-link px-2 active" role="menuitem">Home</a> </li>
                <li> <a href="/download" class="nav-link px-2" role="menuitem">Download</a> </li>
+               <li> <a href="https://github.com/transmission/transmission/blob/main/docs/README.md" class="nav-link px-2" role="menuitem">Documentation</a> </li>
                <li> <a href="/addons" class="nav-link px-2" role="menuitem">Add-Ons</a> </li>
                <li class="dropdown"> <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="menuitem"
                      aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">Community</a>


### PR DESCRIPTION
Today, the documentation pages aren't that easy to find, which can impact users that needs the reference doc to use the tool.
Thus this simple PR to add an obvious link in the menu.